### PR TITLE
get rid of dual select box down arrow in firefox

### DIFF
--- a/app/dynamic-form/components/form-select/form-select.component.scss
+++ b/app/dynamic-form/components/form-select/form-select.component.scss
@@ -1,5 +1,6 @@
 select {
   -webkit-appearance: none;
+  -moz-appearance: none;
   text-indent: .01px;
   text-overflow: '';
   overflow: hidden;


### PR DESCRIPTION
Fixes this:

![screen shot 2017-04-22 at 11 45 25 pm](https://cloud.githubusercontent.com/assets/4152514/25310597/0d182c38-27b6-11e7-8cf0-1018b5e7e586.jpg)
